### PR TITLE
made to work with python 3 and limnoria

### DIFF
--- a/Polls/__init__.py
+++ b/Polls/__init__.py
@@ -27,14 +27,17 @@ __contributors__ = {}
 # This is a url where the most recent plugin package can be downloaded.
 __url__ = '' # 'http://supybot.com/Members/yourname/Polls/download'
 
-import config
-import plugin
+from . import config
+from . import plugin
+from imp import reload
+
+reload(config)
 reload(plugin) # In case we're being reloaded.
 # Add more reloads here if you add third-party modules and want them to be
 # reloaded when this plugin is reloaded.  Don't forget to import them as well!
 
 if world.testing:
-    import test
+    from . import test
 
 Class = plugin.Class
 configure = config.configure

--- a/Polls/plugin.py
+++ b/Polls/plugin.py
@@ -75,7 +75,7 @@ class Polls(callbacks.Plugin, plugins.ChannelDBHandler):
                 cursor.execute(queryString, sqlargs)
             else:
                 cursor.execute(queryString)
-        except Exception, e:
+        except Exception as e:
             self.log.error('Error with sqlite execute: %s' % e)
             self.log.error('For QueryString: %s' % queryString)
             raise


### PR DESCRIPTION
**init**.py now uses relative import, plugin.py uses "Exception as e"
instead of "Exception, e" syntax
